### PR TITLE
Add support for using the new sax parser with EDD.oneFromXml, EDD.oneFromXmlFragment, and EDD.oneFromDatasetsXml.

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/AxisVariableHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/AxisVariableHandler.java
@@ -80,9 +80,4 @@ public class AxisVariableHandler extends StateWithParent {
     }
     content.setLength(0);
   }
-
-  @Override
-  public void popState() {
-    saxHandler.setState(this.completeState);
-  }
 }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridCopyHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridCopyHandler.java
@@ -120,9 +120,4 @@ public class EDDGridCopyHandler extends StateWithParent {
   public void handleDataset(EDD dataset) {
     tSourceEdd = (EDDGrid) dataset;
   }
-
-  @Override
-  public void popState() {
-    saxHandler.setState(this.completeState);
-  }
 }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
@@ -137,6 +137,11 @@ public class HandlerFactory {
     long lastLuceneUpdate = context.getLastLuceneUpdate();
     StringArray changedDatasetIDs = context.getChangedDatasetIDs();
 
+    // erddap == null implies we are in a load one dataset situation, only check the regex.
+    if (erddap == null) {
+      return !datasetID.matches(datasetsRegex);
+    }
+
     if (majorLoad) {
       orphanIDSet.remove(datasetID);
     }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/SaxHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/SaxHandler.java
@@ -1,7 +1,17 @@
 package gov.noaa.pfel.erddap.handlers;
 
+import com.cohort.array.StringArray;
 import com.cohort.util.String2;
+import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.dataset.EDD;
 import gov.noaa.pfel.erddap.util.EDStatic;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -53,5 +63,84 @@ public class SaxHandler extends DefaultHandler {
       String2.log(e.getMessage());
       this.state.popState();
     }
+  }
+
+  public static EDD parseOneDataset(InputStream inputStream, String datasetId, Erddap erddap)
+      throws ParserConfigurationException, SAXException, IOException {
+    var context = new SaxParsingContext();
+
+    context.setNTryAndDatasets(new int[2]);
+    context.setChangedDatasetIDs(new StringArray());
+    context.setOrphanIDSet(new HashSet<>());
+    context.setDatasetIDSet(new HashSet<>());
+    context.setDuplicateDatasetIDs(new StringArray());
+    context.setDatasetsThatFailedToLoadSB(new StringBuilder());
+    context.setWarningsFromLoadDatasets(new StringBuilder());
+    context.settUserHashMap(new HashMap<>());
+    context.setMajorLoad(false);
+    context.setErddap(erddap);
+    context.setLastLuceneUpdate(System.currentTimeMillis());
+    context.setDatasetsRegex(datasetId);
+    context.setReallyVerbose(false);
+
+    SAXParserFactory factory = SAXParserFactory.newInstance();
+    factory.setXIncludeAware(true);
+    factory.setNamespaceAware(true);
+
+    SAXParser saxParser = factory.newSAXParser();
+    SaxHandler saxHandler = new SaxHandler(context);
+
+    TopLevelDatasetCapture topLevelHandler = new TopLevelDatasetCapture(saxHandler, context);
+
+    saxHandler.setState(topLevelHandler);
+    saxParser.parse(inputStream, saxHandler);
+
+    return topLevelHandler.getDataset();
+  }
+
+  public static void parse(
+      InputStream inputStream,
+      int[] nTryAndDatasets,
+      StringArray changedDatasetIDs,
+      HashSet<String> orphanIDSet,
+      HashSet<String> datasetIDSet,
+      StringArray duplicateDatasetIDs,
+      StringBuilder datasetsThatFailedToLoadSB,
+      StringBuilder warningsFromLoadDatasets,
+      HashMap tUserHashMap,
+      boolean majorLoad,
+      Erddap erddap,
+      long lastLuceneUpdate,
+      String datasetsRegex,
+      boolean reallyVerbose)
+      throws ParserConfigurationException, SAXException, IOException {
+
+    var context = new SaxParsingContext();
+
+    context.setNTryAndDatasets(nTryAndDatasets);
+    context.setChangedDatasetIDs(changedDatasetIDs);
+    context.setOrphanIDSet(orphanIDSet);
+    context.setDatasetIDSet(datasetIDSet);
+    context.setDuplicateDatasetIDs(duplicateDatasetIDs);
+    context.setDatasetsThatFailedToLoadSB(datasetsThatFailedToLoadSB);
+    context.setWarningsFromLoadDatasets(warningsFromLoadDatasets);
+    context.settUserHashMap(tUserHashMap);
+    context.setMajorLoad(majorLoad);
+    context.setErddap(erddap);
+    context.setLastLuceneUpdate(lastLuceneUpdate);
+    context.setDatasetsRegex(datasetsRegex);
+    context.setReallyVerbose(reallyVerbose);
+
+    SAXParserFactory factory = SAXParserFactory.newInstance();
+    factory.setXIncludeAware(true);
+    factory.setNamespaceAware(true);
+
+    SAXParser saxParser = factory.newSAXParser();
+    SaxHandler saxHandler = new SaxHandler(context);
+
+    TopLevelHandler topLevelHandler = new TopLevelHandler(saxHandler, context);
+
+    saxHandler.setState(topLevelHandler);
+    saxParser.parse(inputStream, saxHandler);
   }
 }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelDatasetCapture.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelDatasetCapture.java
@@ -1,0 +1,61 @@
+package gov.noaa.pfel.erddap.handlers;
+
+import com.cohort.util.String2;
+import gov.noaa.pfel.erddap.dataset.EDD;
+import gov.noaa.pfel.erddap.util.EDStatic;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+public class TopLevelDatasetCapture extends State {
+  private SaxParsingContext context;
+  private EDD dataset;
+
+  public TopLevelDatasetCapture(SaxHandler saxHandler, SaxParsingContext context) {
+    super(saxHandler);
+    this.context = context;
+  }
+
+  @Override
+  public void startElement(String uri, String localName, String qName, Attributes attributes) {
+
+    switch (localName) {
+      case "convertToPublicSourceUrl" -> {
+        String tFrom = attributes.getValue("from");
+        String tTo = attributes.getValue("to");
+        int spo = EDStatic.convertToPublicSourceUrlFromSlashPo(tFrom);
+        if (tFrom != null && tFrom.length() > 3 && spo == tFrom.length() - 1 && tTo != null) {
+          EDStatic.convertToPublicSourceUrl.put(tFrom, tTo);
+        }
+      }
+      case "dataset" -> {
+        String datasetType = attributes.getValue("type");
+        String datasetID = attributes.getValue("datasetID");
+        String active = attributes.getValue("active");
+
+        State state =
+            HandlerFactory.getHandlerFor(datasetType, datasetID, active, this, saxHandler, context);
+        saxHandler.setState(state);
+      }
+    }
+  }
+
+  @Override
+  public void characters(char[] ch, int start, int length) throws SAXException {}
+
+  @Override
+  public void endElement(String uri, String localName, String qName) {}
+
+  @Override
+  public void handleDataset(EDD dataset) {
+    this.dataset = dataset;
+  }
+
+  public EDD getDataset() {
+    return this.dataset;
+  }
+
+  @Override
+  public void popState() {
+    String2.log("Attempt to pop top level handler. Something likely went wrong.");
+  }
+}


### PR DESCRIPTION
This fixes a few of the JettyTests as well as make it easier to use the SAX parser in other tests (which heavily use the oneFromXmlFragment call).
